### PR TITLE
snapcraft.yaml: fix Intel hardware acceleration

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -79,6 +79,24 @@ parts:
         -t "${CRAFT_PART_INSTALL}"/usr/local/bin
 
 apps:
+  vainfo:
+    command: usr/bin/vainfo
+    plugs:
+      - opengl
+    environment: &_environment
+      LD_LIBRARY_PATH: /usr/lib/jellyfin-ffmpeg/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/vdpau:$LD_LIBRARY_PATH
+      LIBGL_DRIVERS_PATH: /usr/lib/jellyfin-ffmpeg/lib:/usr/lib/jellyfin-ffmpeg/lib/dri:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:$LIBGL_DRIVERS_PATH
+      LIBVA_DRIVERS_PATH: /usr/lib/jellyfin-ffmpeg/lib:/usr/lib/jellyfin-ffmpeg/lib/dri:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:$LIBVA_DRIVERS_PATH
+  ffmpeg:
+    command: usr/lib/jellyfin-ffmpeg/ffmpeg
+    plugs:
+      - opengl
+    environment: *_environment
+  clinfo:
+    command: usr/bin/clinfo
+    environment: *_environment
+    plugs:
+      - opengl
   itrue-jellyfin:
     command: usr/local/bin/jellyfin.sh
     daemon: simple
@@ -91,24 +109,12 @@ apps:
       - mount-observe
       - firewall-control
     environment:
+      <<: *_environment
       JELLYFIN_LOG_DIR: "${SNAP_DATA}/logs"
       JELLYFIN_CACHE_DIR: "${SNAP_COMMON}/cache"
       JELLYFIN_CONFIG_DIR: "${SNAP_COMMON}/config"
       JELLYFIN_DATA_DIR: "${SNAP_COMMON}/data"
       JELLYFIN_WEB_DIR: "${SNAP}/usr/share/jellyfin/web"
-  vainfo:
-    command: usr/bin/vainfo
-    plugs:
-      - opengl
-  ffmpeg:
-    command: usr/lib/jellyfin-ffmpeg/ffmpeg
-    plugs:
-      - opengl
-  clinfo:
-    command: usr/bin/clinfo
-    environment:
-    plugs:
-      - opengl
 
 environment:
   # Enable OpenCL on older AMD cards
@@ -135,5 +141,7 @@ layout:
     bind: $SNAP/usr/lib/jellyfin-ffmpeg
   /etc/OpenCL:
     bind: $SNAP/etc/OpenCL
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/intel-opencl:
+    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/intel-opencl
   /opt:
     bind: $SNAP/opt


### PR DESCRIPTION
The OpenCL ICD provided by Intel hard-codes the path to the OpenCL library. This works in more traditional use-cases, but because libOpenCL.so is NOT in the usual path here, the usual LD_LIBRARY_PATH workarounds don't necessarily apply. Instead, spoof the location of libOpenCL.so similarly to how spoofing the ICD file itself is done (via a layout).

Closes #12