### PR TITLE
snapcraft.yaml: add 'read:all' attribute to home plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -120,6 +120,10 @@ environment:
   # Enable OpenCL on older AMD cards
   ROC_ENABLE_PRE_VEGA: "1"
 
+plugs:
+  home:
+    read: all
+
 layout:
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio


### PR DESCRIPTION
As the jellyfin service runs as root, the home plug only grants access to /root. As the intention of the plug is to gain access to /home/<user>, instead the `read: all` attribute must be used. This enables the jellyfin service to access every directory in /home/foo.

This of course opens up the opportunity for the snap to view *every* user's home directory, which may be undesirable. But there is (currently) no good method for specifying only a particular user's home directory.