### PR TITLE
Revert "snapcraft.yaml: add 'read:all' attribute to home plug"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -128,10 +128,6 @@ environment:
   # Enable OpenCL on older AMD cards
   ROC_ENABLE_PRE_VEGA: "1"
 
-plugs:
-  home:
-    read: all
-
 layout:
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio


### PR DESCRIPTION
The `read:all` attribute causes the snap to be rejected by the Snap Store as it is a super-privileged interface. The snap cannot get approval for super-privileged interfaces as it's not the official upstream snap.

Reverts IsaacJT/jellyfin-snap#29