### PR TITLE
snap: disable AMD packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ Hardware acceleration support can be tested and debugged using the `itrue-jellyf
 
 - Hardware acceleration support
   - Intel partially supported (YMMV)
-  - AMD is a work-in-progress
+  - ~AMD is a work-in-progress~ AMD packages have been removed because their Apt repository always has some kind of issue and breaks the automatic snap builds
   - Nvidia is not supported due to the proprietary binaries

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,9 @@ description: |
 
   This is a community-developed snap and not officially supported or released
   by Jellyfin.
+title: Jellyfin Server
+donation: https://jellyfin.org/contribute
+website: https://jellyfin.org
 base: core24
 confinement: strict
 adopt-info: jellyfin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,13 +41,6 @@ package-repositories:
     architectures:
       - arm64
       - amd64
-  - type: apt
-    url: https://repo.radeon.com/rocm/apt/debian
-    suites: [jammy]
-    components: [main]
-    key-id: CA8BB4727A47B4D09B4EE8969386B48A1A693C5C
-    architectures:
-      - amd64
 
 parts:
   jellyfin:
@@ -64,7 +57,6 @@ parts:
       - clinfo:${CRAFT_ARCH_BUILD_FOR}
       - on amd64:
         - intel-opencl-icd:${CRAFT_ARCH_BUILD_FOR}
-        - rocm-opencl-runtime:${CRAFT_ARCH_BUILD_FOR}
         - libquadmath0:${CRAFT_ARCH_BUILD_FOR}
     override-build: |
       craftctl default


### PR DESCRIPTION
The AMD Apt repository always has a ton of issues which break the automatic snap builds. Disable the additional repository and packages entirely.