### PR TITLE
Migrate to core26

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 ---
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2021 Canonical Ltd
 
 name: itrue-jellyfin
 summary: "Jellyfin: The Free Software Media System"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -83,6 +83,8 @@ apps:
       - gpu
     plugs:
       - opengl
+      - x11
+      - wayland
     environment: &_environment
       LD_LIBRARY_PATH: /usr/lib/jellyfin-ffmpeg/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/vdpau:$LD_LIBRARY_PATH
       LIBGL_DRIVERS_PATH: /usr/lib/jellyfin-ffmpeg/lib:/usr/lib/jellyfin-ffmpeg/lib/dri:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:$LIBGL_DRIVERS_PATH

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ description: |
 title: Jellyfin Server
 donation: https://jellyfin.org/contribute
 website: https://jellyfin.org
-base: core24
+base: core26
 confinement: strict
 adopt-info: jellyfin
 license: GPL-2.0
@@ -38,7 +38,7 @@ issues: https://github.com/IsaacJT/jellyfin-snap/issues
 package-repositories:
   - type: apt
     url: https://repo.jellyfin.org/ubuntu
-    suites: [noble]
+    suites: [resolute]
     components: [main]
     key-id: 4918AABC486CA052358D778D49023CD01DE21A7B
     architectures:
@@ -53,8 +53,8 @@ parts:
       - jellyfin-web:all
       - jellyfin-ffmpeg7:${CRAFT_ARCH_BUILD_FOR}
       - va-driver-all:${CRAFT_ARCH_BUILD_FOR}
-      - libavcodec60:${CRAFT_ARCH_BUILD_FOR}
-      - libavcodec-extra60:${CRAFT_ARCH_BUILD_FOR}
+      - libavcodec62:${CRAFT_ARCH_BUILD_FOR}
+      - libavcodec-extra62:${CRAFT_ARCH_BUILD_FOR}
       - vainfo:${CRAFT_ARCH_BUILD_FOR}
       - libdrm-common:${CRAFT_ARCH_BUILD_FOR}
       - clinfo:${CRAFT_ARCH_BUILD_FOR}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,7 @@
 # Copyright (C) 2021 Canonical Ltd
 
 name: itrue-jellyfin
-summary:  "Jellyfin: The Free Software Media System"
+summary: "Jellyfin: The Free Software Media System"
 description: |
   Jellyfin is the volunteer-built media solution that puts you in control of
   your media. Stream to any device from your own server, with no strings
@@ -26,7 +26,7 @@ platforms:
       - amd64
     build-for:
       - amd64
-  arm64: 
+  arm64:
     build-on:
       - arm64
     build-for:
@@ -56,11 +56,7 @@ parts:
       - libavcodec62:${CRAFT_ARCH_BUILD_FOR}
       - libavcodec-extra62:${CRAFT_ARCH_BUILD_FOR}
       - vainfo:${CRAFT_ARCH_BUILD_FOR}
-      - libdrm-common:${CRAFT_ARCH_BUILD_FOR}
       - clinfo:${CRAFT_ARCH_BUILD_FOR}
-      - on amd64:
-        - intel-opencl-icd:${CRAFT_ARCH_BUILD_FOR}
-        - libquadmath0:${CRAFT_ARCH_BUILD_FOR}
     override-build: |
       craftctl default
       craftctl set grade="stable"
@@ -84,6 +80,8 @@ parts:
 apps:
   vainfo:
     command: usr/bin/vainfo
+    extensions:
+      - gpu
     plugs:
       - opengl
     environment: &_environment
@@ -92,17 +90,23 @@ apps:
       LIBVA_DRIVERS_PATH: /usr/lib/jellyfin-ffmpeg/lib:/usr/lib/jellyfin-ffmpeg/lib/dri:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:$LIBVA_DRIVERS_PATH
   ffmpeg:
     command: usr/lib/jellyfin-ffmpeg/ffmpeg
+    extensions:
+      - gpu
     plugs:
       - opengl
     environment: *_environment
   clinfo:
     command: usr/bin/clinfo
     environment: *_environment
+    extensions:
+      - gpu
     plugs:
       - opengl
   itrue-jellyfin:
     command: usr/local/bin/jellyfin.sh
     daemon: simple
+    extensions:
+      - gpu
     plugs:
       - network
       - network-bind
@@ -118,10 +122,6 @@ apps:
       JELLYFIN_CONFIG_DIR: "${SNAP_COMMON}/config"
       JELLYFIN_DATA_DIR: "${SNAP_COMMON}/data"
       JELLYFIN_WEB_DIR: "${SNAP}/usr/share/jellyfin/web"
-
-environment:
-  # Enable OpenCL on older AMD cards
-  ROC_ENABLE_PRE_VEGA: "1"
 
 layout:
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:
@@ -148,3 +148,11 @@ layout:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/intel-opencl
   /opt:
     bind: $SNAP/opt
+
+lint:
+  ignore:
+    # Custom libaries for jellyfin-ffmpeg
+    - library:
+        - usr/lib/jellyfin-ffmpeg/lib/*
+    - gpu:
+        - usr/lib/jellyfin-ffmpeg/lib/*


### PR DESCRIPTION
- Switch to core26
- Update package names
- Remove GPU packages
- Switch to using the GPU extension