### PR TITLE
snap: harden daemon shutdown and trim primed docs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,6 +65,7 @@ parts:
     # yamllint enable rule:line-length
     prime:
       - -usr/share/man
+      - -usr/share/doc
       - -var/spool
 
   scripts:
@@ -109,6 +110,8 @@ apps:
   itrue-jellyfin:
     command: usr/local/bin/jellyfin.sh
     daemon: simple
+    stop-timeout: 60s
+    restart-condition: on-failure
     extensions:
       - gpu
     plugs:


### PR DESCRIPTION
- daemon: add stop-timeout (60s) and explicit restart-condition: on-failure to give Jellyfin time to flush its SQLite database on stop/refresh/reboot.
- prime: also exclude usr/share/doc to reduce snap size.